### PR TITLE
"update" parent images to debian bookworm

### DIFF
--- a/game-server/Dockerfile
+++ b/game-server/Dockerfile
@@ -1,6 +1,9 @@
-FROM ubuntu:bionic
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=NONINTERACTIVE
 
 RUN dpkg --add-architecture i386 \
+    && sed -i 's/^Components: main$/& contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources \
     && apt-get update && apt-get install --no-install-recommends -y \
         xvfb \
         wine32 \
@@ -9,6 +12,9 @@ RUN dpkg --add-architecture i386 \
         ca-certificates \
         unrar \
         winbind \
+        xauth \
+        cabextract \
+        wget \
     && apt-get clean \
     && useradd -m bfbc2
 

--- a/master-server/Dockerfile
+++ b/master-server/Dockerfile
@@ -1,11 +1,12 @@
-FROM ubuntu:22.04 as makefile
+FROM debian:bookworm as makefile
 
 ENV LIB_BOOST_DIR="/usr/include/boost/"
 ENV LIB_OPENSSL_DIR="/usr/include/openssl/"
 ENV LIB_PATH="/usr/lib"
 
 WORKDIR /bfbc2
-RUN apt-get update && apt-get install -y \
+RUN sed -i 's/^Components: main$/& contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources \
+    && apt-get update && apt-get install -y \
         unrar \
         cbp2make \
         wget \


### PR DESCRIPTION
Ubuntu Bionic has been EOL for a while now, so I switched the game- and master-server image to Debian Bookworm.